### PR TITLE
🔀 :: (#143) 주말외출 알람 Cron 시간 변경

### DIFF
--- a/application-infrastructure/src/main/java/io/github/v1serviceapplication/infrastructure/notification/scheduler/NotificationScheduler.java
+++ b/application-infrastructure/src/main/java/io/github/v1serviceapplication/infrastructure/notification/scheduler/NotificationScheduler.java
@@ -5,17 +5,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-@Component
 @RequiredArgsConstructor
+@Component
 public class NotificationScheduler {
 
-    private final NotificationSpi notificationSpi;
     private static final String APPLICATION_WEEKEND_PICNIC = "APPLICATION_WEEKEND_PICNIC";
     private static final String WEEKEND_APPLICATION_CONTENT = "주말외출 예약 기간입니다.";
     private static final String THREAD_ID = "weekend-application";
+    private final NotificationSpi notificationSpi;
 
-
-    @Scheduled(cron = "0 0 22 ? * FRI", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 21 * * FRI-SAT", zone = "Asia/Seoul")
     public void weekendApplicationNotification() {
         notificationSpi.sendGroupNotification(
                 APPLICATION_WEEKEND_PICNIC,


### PR DESCRIPTION
주말외출이 20시 30분부터 시작하지만 20시 30분에 보내면 확인하지 못할 수 있기 때문에 21시에 보내주기 위해 시간을 21시로 설정하고
금요일, 토요일에 다음날 외출 신청이 가능하다는걸 공지하기 위해 했습니다